### PR TITLE
Use actual filename of uploaded media instead of "subtitles.srt" when downloading transcription

### DIFF
--- a/frontend/src/lib/components/ModalDownloadOptions.svelte
+++ b/frontend/src/lib/components/ModalDownloadOptions.svelte
@@ -10,16 +10,19 @@
         console.log("download subtitle");
         let segments = [];
         let text = "";
+        let title = "subtitles";
 
         console.log(language)
         if (language == "original") {
             segments = tr.result.segments;
             text = tr.result.text;
+            title = tr.fileName.split("_WHSHPR_")[1]
         } else {
             for (const translation of tr.translations) {
                 if (translation.targetLanguage == language) {
                     segments = translation.result.segments;
                     text = translation.result.text;
+                    title = tr.fileName.split("_WHSHPR_")[1]
                     break;
                 }
             }
@@ -31,13 +34,13 @@
         }
 
         if (subtitleFormat == "srt") {
-            downloadSRT(segments);
+            downloadSRT(segments, title);
         } else if (subtitleFormat == "vtt") {
-            downloadVTT(segments);
+            downloadVTT(segments, title);
         } else if (subtitleFormat == "json") {
-            downloadJSON(tr.result);
+            downloadJSON(tr.result, title);
         } else if (subtitleFormat == "txt") {
-            downloadTXT(text);
+            downloadTXT(text, title);
         }
     }
 

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -53,7 +53,7 @@ export const getRandomSentence = function () {
 }
 
 // Expects a segments array with start, end and text properties
-export const downloadSRT = function (jsonData) {
+export const downloadSRT = function (jsonData, title) {
     let srtContent = '';
     
     jsonData.forEach((segment, index) => {
@@ -71,32 +71,32 @@ export const downloadSRT = function (jsonData) {
     let url = URL.createObjectURL(srtBlob);
     let link = document.createElement('a');
     link.href = url;
-    link.download = 'subtitles.srt';
+    link.download = `${title}.srt`;
     link.click();
 }
 
 // Downloads received text as a TXT file
-export const downloadTXT = function (text) {
+export const downloadTXT = function (text, title) {
     let srtBlob = new Blob([text], {type: 'text/plain'});
     let url = URL.createObjectURL(srtBlob);
     let link = document.createElement('a');
     link.href = url;
-    link.download = 'subtitles.txt';
+    link.download = `${title}.txt`;
     link.click();
 }
 
 // Downloads received JSON data as a JSON file
-export const downloadJSON = function (jsonData) {
+export const downloadJSON = function (jsonData, title) {
     let srtBlob = new Blob([JSON.stringify(jsonData)], {type: 'text/plain'});
     let url = URL.createObjectURL(srtBlob);
     let link = document.createElement('a');
     link.href = url;
-    link.download = 'subtitles.json';
+    link.download = `${title}.json`;
     link.click();
 }
 
 // Expects a segments array with start, end and text properties
-export const downloadVTT = function (jsonData) {
+export const downloadVTT = function (jsonData, title) {
     let vttContent = 'WEBVTT\n\n'; // VTT files start with "WEBVTT" line
   
     jsonData.forEach((segment, index) => {
@@ -115,7 +115,7 @@ export const downloadVTT = function (jsonData) {
     let url = URL.createObjectURL(vttBlob);
     let link = document.createElement('a');
     link.href = url;
-    link.download = 'subtitles.vtt';
+    link.download = `${title}.vtt`;
     link.click();
 }
   


### PR DESCRIPTION
I've changed the filename when downloading a transcription to be the original filename of the media instead of a generic  "subtitles".

I'm not experienced with Svelte or with Javascript, so it might be a "wrong" way to do it, but it does work