### PR TITLE
Return Transcription JSON on `handlePostTranscription`

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -101,9 +101,20 @@ func (s *Server) handlePostTranscription(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "Internal server error")
 	}
 
-	// Write the JSON to the response body.
+	// Broadcast transcription to websocket clients
 	s.BroadcastTranscription(res)
 	s.NewTranscriptionCh <- true
+	
+	// Convert the transcription to JSON.
+	json, err := json.Marshal(res)
+	if err != nil {
+		// 503 On vacation!
+		return fiber.NewError(fiber.StatusServiceUnavailable, "On vacation!")
+	}
+
+	// Write the JSON to the response body.
+	c.Set("Content-Type", "application/json")
+	c.Write(json)
 	return nil
 }
 


### PR DESCRIPTION
I can't find any good reason why the newly created transcription data is not returned in the /POST route.

Developers that don't plan to integrate websockets in their apps have to resort to some clunky handling which can lead to a myriad of bad practices.

Say for example I have a NextJS app and a serverless function to POST transcription requests to Whishper. There is no way to get the ID of the newly created object without:
 - Creating a separate express server that listens to the websocket and updates the DB that is used by the Next app.
 - Connecting to the Mongo db manually and searching for the `sourceUrl` or file name.

Can't decide which is worse right now. 

My conclusion is that it's really easy to just return the data, so the server which makes the requests knows what ID to use to then query the `/api/transcriptions/:id` route.

If this is not wanted/needed, please explain the logic behind.