### PR TITLE
Stick numpy on v1.

### DIFF
--- a/whisperx-api/requirements.txt
+++ b/whisperx-api/requirements.txt
@@ -1,5 +1,5 @@
 whisperx @ git+https://github.com/m-bain/whisperx.git
-numpy
+numpy==1.26.4
 pydantic
 python-dotenv
 Requests


### PR DESCRIPTION
NumPy 2.0 is released.

https://numpy.org/news/#numpy-200-released

PIP will install v2 by default and get into this error. It could better to stick with v1 before migration.

```
Jun 22 08:39:52 anysub python3[7813]: /usr/local/lib/python3.11/dist-packages/pyannote/audio/core/io.py:43: UserWarning: torchaudio._backend.set_audio_backend has been deprecated. With dispatcher enabled, this function is no-op. You can remove the function call.
Jun 22 08:39:52 anysub python3[7813]:   torchaudio.set_audio_backend("soundfile")
Jun 22 08:39:52 anysub python3[7813]: Traceback (most recent call last):
Jun 22 08:39:52 anysub python3[7813]:   File "/opt/anysub/whisperx-api/main.py", line 6, in <module>
Jun 22 08:39:52 anysub python3[7813]:     from transcribe import transcribe_file, transcribe_from_filename
Jun 22 08:39:52 anysub python3[7813]:   File "/mnt/repos/whishper/whisperx-api/transcribe.py", line 6, in <module>
Jun 22 08:39:52 anysub python3[7813]:     from backends.wx import WhisperxBackend
Jun 22 08:39:52 anysub python3[7813]:   File "/mnt/repos/whishper/whisperx-api/backends/wx.py", line 5, in <module>
Jun 22 08:39:52 anysub python3[7813]:     import whisperx
Jun 22 08:39:52 anysub python3[7813]:   File "/usr/local/lib/python3.11/dist-packages/whisperx/__init__.py", line 1, in <module>
Jun 22 08:39:52 anysub python3[7813]:     from .transcribe import load_model
Jun 22 08:39:52 anysub python3[7813]:   File "/usr/local/lib/python3.11/dist-packages/whisperx/transcribe.py", line 10, in <module>
Jun 22 08:39:52 anysub python3[7813]:     from .asr import load_model
Jun 22 08:39:52 anysub python3[7813]:   File "/usr/local/lib/python3.11/dist-packages/whisperx/asr.py", line 13, in <module>
Jun 22 08:39:52 anysub python3[7813]:     from .vad import load_vad_model, merge_chunks
Jun 22 08:39:52 anysub python3[7813]:   File "/usr/local/lib/python3.11/dist-packages/whisperx/vad.py", line 9, in <module>
Jun 22 08:39:52 anysub python3[7813]:     from pyannote.audio import Model
Jun 22 08:39:52 anysub python3[7813]:   File "/usr/local/lib/python3.11/dist-packages/pyannote/audio/__init__.py", line 29, in <module>
Jun 22 08:39:52 anysub python3[7813]:     from .core.inference import Inference
Jun 22 08:39:52 anysub python3[7813]:   File "/usr/local/lib/python3.11/dist-packages/pyannote/audio/core/inference.py", line 49, in <module>
Jun 22 08:39:52 anysub python3[7813]:     class Inference(BaseInference):
Jun 22 08:39:52 anysub python3[7813]:   File "/usr/local/lib/python3.11/dist-packages/pyannote/audio/core/inference.py", line 533, in Inference
Jun 22 08:39:52 anysub python3[7813]:     missing: float = np.NaN,
Jun 22 08:39:52 anysub python3[7813]:                      ^^^^^^
Jun 22 08:39:52 anysub python3[7813]:   File "/usr/local/lib/python3.11/dist-packages/numpy/__init__.py", line 397, in __getattr__
Jun 22 08:39:52 anysub python3[7813]:     raise AttributeError(
Jun 22 08:39:52 anysub python3[7813]: AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.. Did you mean: 'nan'?
```