### PR TITLE
Add DB credentials as environment variables to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       - mongo
       - translate
     environment:
+      DB_USER: ${DB_USER:-whishper}
+      DB_PASS: ${DB_PASS:-whishper}
       PUBLIC_INTERNAL_API_HOST: "http://127.0.0.1:80"
       PUBLIC_TRANSLATION_API_HOST: ""
       PUBLIC_API_HOST: ${WHISHPER_HOST:-}


### PR DESCRIPTION
Adds `DB_USER` and `DB_PASS` environment variables to the Whishper service to fix an issue whereby the app wasn't able to write to Mongo due to authentication errors:

```
Error saving transcription to database [36merror=[0m[31m"connection() error occurred during connection handshake: auth error: sasl conversation error: unable to authenticate using mechanism \"SCRAM-SHA-1\": (AuthenticationFailed) Authentication failed."
```