### PR TITLE
Remove version keyword from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   mongo:
     image: mongo


### PR DESCRIPTION
It's deprecated and produces a warning