### PR TITLE
get-whisper.sh: Do not crash when user-provided directory already exists

### DIFF
--- a/get-whishper.sh
+++ b/get-whishper.sh
@@ -32,7 +32,7 @@ else
     echo -e "${BLUE}> Enter the name of the directory where you want to set up everything:${NC}"
     read directory
     echo -e "ℹ️  Setting up everything in the $directory directory"
-    mkdir $directory
+    mkdir -p $directory
     cd $directory
 fi
 


### PR DESCRIPTION
Currently, `get-whishper.sh` crashes if the user-provided installation directory already exists. This PR changes that.