### PR TITLE
Add TXT raw and segmented download options

### DIFF
--- a/frontend/src/lib/components/ModalDownloadOptions.svelte
+++ b/frontend/src/lib/components/ModalDownloadOptions.svelte
@@ -39,8 +39,14 @@
             downloadVTT(segments, title);
         } else if (subtitleFormat == "json") {
             downloadJSON(tr.result, title);
-        } else if (subtitleFormat == "txt") {
+        } else if (subtitleFormat == "txt_raw") {
             downloadTXT(text, title);
+        } else if (subtitleFormat == "txt_segmented" || subtitleFormat == "txt") {
+            // One subtitle segment per line for readability.
+            const textBySegments = segments.length > 0
+                ? segments.map((segment) => segment.text?.trim() ?? "").filter(Boolean).join("\n")
+                : text;
+            downloadTXT(textBySegments, title);
         }
     }
 
@@ -92,7 +98,8 @@
                     <option value="srt">SRT</option>
                     <option value="vtt">VTT</option>
                     <option value="json">JSON</option>
-                    <option value="txt">TXT</option>
+                    <option value="txt_raw">TXT (Raw)</option>
+                    <option value="txt_segmented">TXT (Segmented)</option>
                 </select>
             </div>
     


### PR DESCRIPTION
## Summary
This PR improves TXT export options in the download modal by adding two explicit formats:
- `TXT (Raw)`: preserves the previous behavior (single continuous text block)
- `TXT (Segmented)`: exports one subtitle segment per line for better readability

## Changes
- Updated `frontend/src/lib/components/ModalDownloadOptions.svelte`
- Added new format options in the selector:
  - `txt_raw`
  - `txt_segmented`
- Updated download logic:
  - `txt_raw` -> uses existing full text export
  - `txt_segmented` -> builds TXT from `segments` with newline separation
- Kept backward compatibility by handling legacy `txt` as segmented output

## Why
Previously, TXT export produced one long line, which can be hard to read for long transcripts.  
With this change, users can choose between raw text and segment-by-segment formatting depending on their workflow.

## Testing
- Verified `TXT (Raw)` still exports the original full text behavior
- Verified `TXT (Segmented)` exports each segment on a new line
- Verified existing download formats (`SRT`, `VTT`, `JSON`) remain unchanged